### PR TITLE
Add throttling to certain application lifecycle events

### DIFF
--- a/PostHog/Classes/PHGPostHogConfiguration.h
+++ b/PostHog/Classes/PHGPostHogConfiguration.h
@@ -90,6 +90,10 @@ typedef NSMutableURLRequest *_Nonnull (^PHGRequestFactory)(NSURL *_Nonnull);
  */
 @property (nonatomic, assign) BOOL captureApplicationLifecycleEvents;
 
+/**
+ * The throttle interval for certain application lifecycle events, such as "Application Opened" (from background) and "Application Backgrounded". 900 seconds by default.
+ */
+@property (nonatomic, assign) NSTimeInterval applicationLifecycleEventsThrottleInterval;
 
 /**
  * Whether the posthog client should record bluetooth information. If `YES`, please make sure to add a description for `NSBluetoothPeripheralUsageDescription` in your `Info.plist` explaining explaining why your app is accessing Bluetooth APIs. `NO` by default.

--- a/PostHog/Classes/PHGPostHogConfiguration.m
+++ b/PostHog/Classes/PHGPostHogConfiguration.m
@@ -55,6 +55,7 @@
         self.flushAt = 20;
         self.flushInterval = 30;
         self.maxQueueSize = 1000;
+        self.applicationLifecycleEventsThrottleInterval = 900; // 15 minutes in seconds
         self.libraryName = @"posthog-ios";
         self.libraryVersion = [PHGPostHog version];
         self.payloadFilters = @{


### PR DESCRIPTION
**What does this PR do?**

Adds a new `applicationLifecycleEventsThrottleInterval` config property, set to 15 min by default, which throttles the capture of some application lifecycle events, like "Application Opened" (from background) and "Application Backgrounded" (these events won't be captured unless 15 minutes have passed in between executions).

**What are the relevant tickets?**

https://github.com/trustwallet/ios/issues/5249